### PR TITLE
appdata, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Image Optimzer
+# Image Optimizer
 [![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.gijsgoudzwaard.image-optimizer)
 
-Simple losless image optimizer build for [Elementary OS](https://elementary.io).
+Simple lossless image optimizer built for [elementary OS](https://elementary.io).
 
 ![Screenshot](data/screenshots/welcome-screen.png)
 

--- a/data/com.github.gijsgoudzwaard.image-optimizer.appdata.xml.in
+++ b/data/com.github.gijsgoudzwaard.image-optimizer.appdata.xml.in
@@ -1,22 +1,28 @@
-
-
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 Gijs Goudzwaard <gijs.goudzwaard@gmail.com> -->
 <component type="desktop">
    <id>com.github.gijsgoudzwaard.image-optimizer.desktop</id>
-   <metadata_license>CC0</metadata_license>
+   <metadata_license>CC0-1.0</metadata_license>
    <name>Image Optimizer</name>
+   <name xml:lang="nb">Image Optimizer</name>
    <developer_name>Gijs Goudzwaard</developer_name>
    <project_license>MIT</project_license>
    <summary>Simple lossless image compression</summary>
+   <summary xml:lang="nb">Enkel tapsfri bildekomprimering</summary>
    <description>
-      <p>Compress your images with ease using JpegOptim and OptiPng</p>
+      <p>Compress your images with ease without the cost of loosing the images quality using JpegOptim and OptiPng.</p>
+      <p xml:lang="nb">Komprimer bildene dine enkelt uten å miste bildekvaliteten med JpegOptim og OptiPng.</p>
       <p>Features:</p>
-      <ul>
-         <li>Easily quit the application by pressing Control + q</li>
-         <li>
-            Compress jpg / jpeg, png, bmp, pnm and tiff with lossless compression
-         </li>
+      <p xml:lang="nb">Egenskaper:</p>
+      <ul>         
+         <li>Compress bmp, jpg / jpeg, png, pnm and tiff with lossless compression</li>
+         <li xml:lang="nb">Komprimerer bmp, jpg / jpeg, png, pnm og tiff med tapsfri komprimering</li>
+         <li>Works offline, always ready where and whenever needed</li>
+         <li xml:lang="nb">Virker uten internett, alltid klar hvor og når det er nødvendig</li>
+         <li>A clean interface, optimize your images effortlessly</li>
+         <li xml:lang="nb">Et rent grensesnitt, optimaliser bildene dine uten problemer</li>
+         <li>Easily quit the application by pressing Ctrl + Q</li>
+         <li xml:lang="nb">Avslutt programmet enkelt ved å trykke Ctrl + Q</li>
       </ul>
    </description>
    <url type="homepage">https://github.com/gijsgoudzwaard/image-optimizer</url>
@@ -37,7 +43,17 @@
       <value key="x-appcenter-suggested-price">2</value>
    </custom>
    <releases>
-      <release version="0.1.9" date="2018-08-03">
+     <release version="0.1.11" date="2018-08-03">
+        <description>
+           <p>Getting things ready for Juno, #27 should be fixed.</p>
+        </description>
+     </release>
+     <release version="0.1.10" date="2018-07-03">
+        <description>
+           <p>Fixed unmet dependencies.</p>
+        </description>
+     </release>
+      <release version="0.1.9" date="2018-07-03">
          <description>
             <p>Getting things ready for Juno.</p>
          </description>
@@ -73,5 +89,5 @@
          </description>
       </release>
    </releases>
+   <content_rating type="oars-1.1" />
 </component>
-


### PR DESCRIPTION
This is a extremely useful project you have here! I hope you appreciate a little drive-by contribution :)

Appdata: 
* appstreamcli was unable to parse the XML data, fixed by removing redundant lineshifts
* Updated `metadata_license` (CC0 > CC0-1.0) to comply with [SPDX](https://spdx.org/licenses/)
* Added Norwegian Bokmål translation for name, summary and description
* Added `release/` for recent releases and corrected date of release
* Expanded the description and added a few more bulletpoints. This should make the app description validate with appstream-util (Note: appstream-util may still say "style-invalid" for the `<p>` in the release descriptions being too short)
* Added [OARS](https://hughsie.github.io/oars/) tag (content age rating, [required](https://github.com/flathub/flathub/wiki/App-Requirements) by Flathub)
* Minor edits

Readme:
* Minor edits