### PR TITLE
Fix build warnings

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,7 +19,7 @@ class Application : Granite.Application {
     var quit_action = new SimpleAction ("quit", null);
 
     add_action (quit_action);
-    add_accelerator ("<Control>q", "app.quit", null);
+    set_accels_for_action ("app.quit", {"<Control>q"});
 
     quit_action.activate.connect (() => {
       if (this.app_window != null) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -55,13 +55,18 @@ public class MainWindow : Gtk.Window {
       width_request: 980
     );
 
-    this.images = images;
+    var css_provider = new Gtk.CssProvider ();
+    try {
+      css_provider.load_from_data (Stylesheet.STYLES);
 
-    Granite.Widgets.Utils.set_theming_for_screen (
-      this.get_screen(),
-      Stylesheet.STYLES,
-      Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-    );
+      Gtk.StyleContext.add_provider_for_screen (
+        this.get_screen(),
+        css_provider,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+      );
+    } catch (Error e) {
+      stdout.printf ("Error: %s\n", e.message);
+    }
   }
 
   construct {

--- a/src/Utils/JpegOptim.vala
+++ b/src/Utils/JpegOptim.vala
@@ -72,7 +72,7 @@ public class JpegOptim {
       return null;
     };
 
-    new Thread<void*>.try("thread", run);
+    new Thread<void*>.try("thread", (owned) run);
   }
 
   /**

--- a/src/Utils/OptiPng.vala
+++ b/src/Utils/OptiPng.vala
@@ -76,7 +76,7 @@ public class OptiPng {
       return null;
     };
 
-    new Thread<void*>.try("thread", run);
+    new Thread<void*>.try("thread", (owned) run);
   }
 
   /**

--- a/src/Widgets/List.vala
+++ b/src/Widgets/List.vala
@@ -23,7 +23,7 @@ public class List {
     this.upload_button.get_style_context().add_class("add");
     this.upload_button.set_valign(Gtk.Align.START);
     this.upload_button.set_halign(Gtk.Align.END);
-    this.upload_button.set_focus_on_click(false);
+    ((Gtk.Widget) this.upload_button).set_focus_on_click(false);
 
     Gtk.TreeIter iter;
     foreach (var image in this.images) {

--- a/src/Widgets/UploadScreen.vala
+++ b/src/Widgets/UploadScreen.vala
@@ -31,7 +31,7 @@ public class UploadScreen : Gtk.Box {
     this.upload_button.get_style_context().add_class("upload_button");
     this.upload_button.set_valign(Gtk.Align.CENTER);
     this.upload_button.set_halign(Gtk.Align.CENTER);
-    upload_button.set_focus_on_click(false);
+    ((Gtk.Widget) this.upload_button).set_focus_on_click(false);
 
     if (icon != null) {
       upload_area.pack_start(icon, false, false, 0);


### PR DESCRIPTION
Fix the following build warnings:

```
../src/Widgets/UploadScreen.vala:34.5-34.36: warning: `Gtk.Button.set_focus_on_click' has been deprecated since 3.20
   34 |     upload_button.set_focus_on_click(false);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/Widgets/List.vala:26.5-26.41: warning: `Gtk.Button.set_focus_on_click' has been deprecated since 3.20
   26 |     this.upload_button.set_focus_on_click(false);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/Utils/JpegOptim.vala:50.5-50.21: warning: delegates with scope="async" must be owned
   50 |     ThreadFunc<void*> run = () => {
      |     ^~~~~~~~~~~~~~~~~
../src/Utils/OptiPng.vala:50.5-50.21: warning: delegates with scope="async" must be owned
   50 |     ThreadFunc<void*> run = () => {
      |     ^~~~~~~~~~~~~~~~~
../src/MainWindow.vala:58.5-58.24: warning: Assignment to same variable
   58 |     this.images = images;
      |     ^~~~~~~~~~~~~~~~~~~~
../src/MainWindow.vala:60.5-60.48: warning: `Granite.Widgets.Utils.set_theming_for_screen' has been deprecated since 5.5.0. Use Gtk.StyleContext.add_provider_for_screen
   60 |     Granite.Widgets.Utils.set_theming_for_screen (
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/Application.vala:22.5-22.19: warning: `Gtk.Application.add_accelerator' has been deprecated since 3.14
   22 |     add_accelerator ("<Control>q", "app.quit", null);
      |     ^~~~~~~~~~~~~~~
Compilation succeeded - 7 warning(s)
```