### PR TITLE
Fix 'Error Occurred' message on quit

### DIFF
--- a/src/Utils/Image.vala
+++ b/src/Utils/Image.vala
@@ -51,10 +51,12 @@ public class Image {
     File file = File.new_for_path (path);
     int64 file_size = 0;
 
-    try {
-      file_size = file.query_info ("*", FileQueryInfoFlags.NONE).get_size ();
-    } catch (Error e) {
-      stdout.printf ("Error occurred");
+    if (file.query_exists ()) {
+      try {
+        file_size = file.query_info ("*", FileQueryInfoFlags.NONE).get_size ();
+      } catch (Error e) {
+        stdout.printf ("Error occurred");
+      }
     }
 
     this.size = file_size;

--- a/src/Utils/Image.vala
+++ b/src/Utils/Image.vala
@@ -55,7 +55,7 @@ public class Image {
       try {
         file_size = file.query_info ("*", FileQueryInfoFlags.NONE).get_size ();
       } catch (Error e) {
-        stdout.printf ("Error occurred");
+        warning ("Failed to get size of \"%s\": %s", this.path, e.message);
       }
     }
 

--- a/src/Utils/JpegOptim.vala
+++ b/src/Utils/JpegOptim.vala
@@ -65,7 +65,7 @@ public class JpegOptim {
           this.list.updateSize(image, new_size);
 
         } catch (SpawnError e) {
-          stdout.printf ("Error: %s\n", e.message);
+          warning ("Failed to spawn jpegoptim: %s", e.message);
         }
       }
 

--- a/src/Utils/OptiPng.vala
+++ b/src/Utils/OptiPng.vala
@@ -69,7 +69,7 @@ public class OptiPng {
 
           this.list.updateSize(image, new_size);
         } catch (SpawnError e) {
-          stdout.printf ("Error: %s\n", e.message);
+          warning ("Failed to spawn optipng: %s", e.message);
         }
       }
 

--- a/src/Utils/Optimizer.vala
+++ b/src/Utils/Optimizer.vala
@@ -37,7 +37,7 @@ public class Optimizer {
       jpegoptim.compress ();
       optipng.compress ();
     } catch (Error e) {
-      stdout.printf ("Error: %s\n", e.message);
+      warning ("Failed to compress: %s", e.message);
     }
   }
 }


### PR DESCRIPTION
Fixes #71

We're initializing the Image class with blank path here:

https://github.com/GijsGoudzwaard/Image-Optimizer/blob/4d525e9cc0792331a1435c351014152c93bb7dd5/src/Widgets/List.vala#L91

Here the Image class tries to get file size of the blank path, and that causes the `Error occurred` message.

---

Also I improved logs while I'm here to make debugging the app earier:

- Use 'warning()' instead of printf that only flashes after quitting the app
- Unique log message to determine where error occurrs
- Include usable info like path in log messages
- Remove trailing newline because 'warning()' automatically adds it