### PR TITLE
Fix crash when image path contains encoded URI

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -31,7 +31,7 @@ jobs:
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: reco.flatpak
-          manifest-path: build-aux/appcenter/com.github.gijsgoudzwaard.image-optimizer.yml
+          manifest-path: com.github.gijsgoudzwaard.image-optimizer.yml
           run-tests: true
           repository-name: appcenter
           repository-url: https://flatpak.elementary.io/repo.flatpakrepo

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -5,12 +5,12 @@ class Application : Granite.Application {
   private Image[] images = {};
   private MainWindow app_window;
 
-  public Application() {
+  public Application () {
     Object (application_id: "com.github.gijsgoudzwaard.image-optimizer",
         flags: GLib.ApplicationFlags.HANDLES_OPEN);
   }
 
-  protected override void activate() {
+  protected override void activate () {
     if (this.app_window == null) {
       this.app_window = new MainWindow (this);
       this.app_window.show_all();
@@ -28,7 +28,7 @@ class Application : Granite.Application {
     });
   }
 
-  public override void open(File[] files, string hint) {
+  public override void open (File[] files, string hint) {
     if (files [0].query_exists ()) {
       foreach (File file in files) {
         var uri = file.get_path().replace("%20", " ").replace("file://", "");
@@ -36,7 +36,7 @@ class Application : Granite.Application {
         var name = Image.getFileName (uri);
         var type = Image.getFileType (file.get_basename());
 
-        if (Image.isValid (type.down())) {
+        if (Image.isValid (type.down ())) {
           this.images += new Image (uri, name, type.down());
         } else {
           // TODO: add an error message here
@@ -45,10 +45,10 @@ class Application : Granite.Application {
 
       if (this.app_window == null) {
         this.app_window = new MainWindow (this);
-        this.app_window.show_all();
+        this.app_window.show_all ();
       }
 
-      this.app_window.set_images(this.images);
+      this.app_window.set_images (this.images);
     }
   }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -13,7 +13,7 @@ class Application : Granite.Application {
   protected override void activate () {
     if (this.app_window == null) {
       this.app_window = new MainWindow (this);
-      this.app_window.show_all();
+      this.app_window.show_all ();
     }
 
     var quit_action = new SimpleAction ("quit", null);
@@ -31,13 +31,13 @@ class Application : Granite.Application {
   public override void open (File[] files, string hint) {
     if (files [0].query_exists ()) {
       foreach (File file in files) {
-        var uri = file.get_path().replace("%20", " ").replace("file://", "");
+        var uri = file.get_path ().replace ("%20", " ").replace ("file://", "");
 
         var name = Image.getFileName (uri);
-        var type = Image.getFileType (file.get_basename());
+        var type = Image.getFileType (file.get_basename ());
 
-        if (Image.isValid (type.down ())) {
-          this.images += new Image (uri, name, type.down());
+        if (Image.is_valid (type.down ())) {
+          this.images += new Image (uri, name, type.down ());
         } else {
           // TODO: add an error message here
         }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -33,8 +33,8 @@ class Application : Granite.Application {
       foreach (File file in files) {
         var uri = file.get_path ().replace ("%20", " ").replace ("file://", "");
 
-        var name = Image.getFileName (uri);
-        var type = Image.getFileType (file.get_basename ());
+        var name = Image.get_file_name (uri);
+        var type = Image.get_file_type (file.get_basename ());
 
         if (Image.is_valid (type.down ())) {
           this.images += new Image (uri, name, type.down ());

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,13 +31,13 @@ class Application : Granite.Application {
   public override void open (File[] files, string hint) {
     if (files [0].query_exists ()) {
       foreach (File file in files) {
-        var uri = file.get_path ().replace ("%20", " ").replace ("file://", "");
+        var path = file.get_path ();
 
-        var name = Image.get_file_name (uri);
+        var name = Image.get_file_name (path);
         var type = Image.get_file_type (file.get_basename ());
 
         if (Image.is_valid (type.down ())) {
-          this.images += new Image (uri, name, type.down ());
+          this.images += new Image (path, name, type.down ());
         } else {
           // TODO: add an error message here
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -189,13 +189,17 @@ public class MainWindow : Gtk.Window {
    */
   private void on_drag_data_received (Gdk.DragContext drag_context, int x, int y, Gtk.SelectionData data, uint info, uint time) {
     foreach (string uri in data.get_uris ()) {
-      uri = uri.replace ("%20", " "). replace ("file://", "");
+      var path = Image.to_path (uri);
+      if (path == null) {
+        warning ("Failed to convert URI \"%s\" to path", uri);
+        continue;
+      }
 
-      var name = Image.get_file_name (uri);
+      var name = Image.get_file_name (path);
       var type = Image.get_file_type (name);
 
       if (Image.is_valid (type.down ())) {
-        this.images += new Image (uri, name, type.down ());
+        this.images += new Image (path, name, type.down ());
       } else {
         // TODO: add an error message here
       }
@@ -226,12 +230,12 @@ public class MainWindow : Gtk.Window {
     file_chooser.select_multiple = true;
 
     if (file_chooser.run () == Gtk.ResponseType.ACCEPT) {
-      foreach (string uri in file_chooser.get_filenames ()) {
-        var name = Image.get_file_name (uri);
+      foreach (string path in file_chooser.get_filenames ()) {
+        var name = Image.get_file_name (path);
         var type = Image.get_file_type (name);
 
         if (Image.is_valid (type.down ())) {
-          this.images += new Image (uri, name, type.down ());
+          this.images += new Image (path, name, type.down ());
         } else {
           // TODO: add an error message here
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -191,8 +191,8 @@ public class MainWindow : Gtk.Window {
     foreach (string uri in data.get_uris ()) {
       uri = uri.replace ("%20", " "). replace ("file://", "");
 
-      var name = Image.getFileName (uri);
-      var type = Image.getFileType (name);
+      var name = Image.get_file_name (uri);
+      var type = Image.get_file_type (name);
 
       if (Image.is_valid (type.down ())) {
         this.images += new Image (uri, name, type.down ());
@@ -227,8 +227,8 @@ public class MainWindow : Gtk.Window {
 
     if (file_chooser.run () == Gtk.ResponseType.ACCEPT) {
       foreach (string uri in file_chooser.get_filenames ()) {
-        var name = Image.getFileName (uri);
-        var type = Image.getFileType (name);
+        var name = Image.get_file_name (uri);
+        var type = Image.get_file_type (name);
 
         if (Image.is_valid (type.down ())) {
           this.images += new Image (uri, name, type.down ());

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -100,7 +100,7 @@ public class MainWindow : Gtk.Window {
    * @param  Image images
    * @return void
    */
-  public void set_images(Image[] images) {
+  public void set_images (Image[] images) {
     this.images = images;
 
     if (images.length == 0) {
@@ -187,15 +187,14 @@ public class MainWindow : Gtk.Window {
    * @param  uint time
    * @return void
    */
-  private void on_drag_data_received (Gdk.DragContext drag_context, int x, int y, Gtk.SelectionData data, uint info, uint time)
-  {
+  private void on_drag_data_received (Gdk.DragContext drag_context, int x, int y, Gtk.SelectionData data, uint info, uint time) {
     foreach (string uri in data.get_uris ()) {
-      uri = uri.replace ("%20", " "). replace("file://", "");
+      uri = uri.replace ("%20", " "). replace ("file://", "");
 
       var name = Image.getFileName (uri);
       var type = Image.getFileType (name);
 
-      if (Image.isValid (type.down ())) {
+      if (Image.is_valid (type.down ())) {
         this.images += new Image (uri, name, type.down ());
       } else {
         // TODO: add an error message here
@@ -205,7 +204,7 @@ public class MainWindow : Gtk.Window {
     if (images.length > 0 && this.images_list == null) {
       this.set_list_window ();
     } else if (this.images_list != null) {
-      this.images_list.updateTreeView (this.images);
+      this.images_list.update_tree_view (this.images);
     }
 
     this.images = {};
@@ -231,7 +230,7 @@ public class MainWindow : Gtk.Window {
         var name = Image.getFileName (uri);
         var type = Image.getFileType (name);
 
-        if (Image.isValid (type.down ())) {
+        if (Image.is_valid (type.down ())) {
           this.images += new Image (uri, name, type.down ());
         } else {
           // TODO: add an error message here
@@ -239,7 +238,7 @@ public class MainWindow : Gtk.Window {
       }
 
       if (this.images_list != null) {
-        this.images_list.updateTreeView (this.images);
+        this.images_list.update_tree_view (this.images);
       }
 
       if (this.images.length > 0) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -36,8 +36,8 @@ public class MainWindow : Gtk.Window {
    *
    * @var Gtk.TargetEntry[]
    */
-  private const Gtk.TargetEntry[] targets = {
-      {"text/uri-list",0,0}
+  private const Gtk.TargetEntry[] TARGETS = {
+      {"text/uri-list", 0, 0}
   };
 
   /**
@@ -60,7 +60,7 @@ public class MainWindow : Gtk.Window {
       css_provider.load_from_data (Stylesheet.STYLES);
 
       Gtk.StyleContext.add_provider_for_screen (
-        this.get_screen(),
+        this.get_screen (),
         css_provider,
         Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
       );
@@ -79,7 +79,7 @@ public class MainWindow : Gtk.Window {
     //    this.images += new Image ("", "", "");
     //  }
 
-    Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, targets, Gdk.DragAction.COPY);
+    Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, TARGETS, Gdk.DragAction.COPY);
     this.drag_leave.connect (this.on_drag_leave);
     this.drag_motion.connect (this.on_drag_motion);
     this.drag_data_received.connect (this.on_drag_data_received);
@@ -131,7 +131,7 @@ public class MainWindow : Gtk.Window {
     add (images_list.window ());
 
     var add_image = new Gtk.Button.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-    add_image.set_tooltip_markup(_("Add Image"));
+    add_image.set_tooltip_markup (_("Add Image"));
     this.toolbar.remove (add_image);
 
     add_image.get_style_context ().add_class ("titlebutton");
@@ -190,13 +190,13 @@ public class MainWindow : Gtk.Window {
   private void on_drag_data_received (Gdk.DragContext drag_context, int x, int y, Gtk.SelectionData data, uint info, uint time)
   {
     foreach (string uri in data.get_uris ()) {
-      uri = uri.replace("%20", " ").replace("file://", "");
+      uri = uri.replace ("%20", " "). replace("file://", "");
 
       var name = Image.getFileName (uri);
       var type = Image.getFileType (name);
 
-      if (Image.isValid (type.down())) {
-        this.images += new Image (uri, name, type.down());
+      if (Image.isValid (type.down ())) {
+        this.images += new Image (uri, name, type.down ());
       } else {
         // TODO: add an error message here
       }
@@ -231,8 +231,8 @@ public class MainWindow : Gtk.Window {
         var name = Image.getFileName (uri);
         var type = Image.getFileType (name);
 
-        if (Image.isValid (type.down())) {
-          this.images += new Image (uri, name, type.down());
+        if (Image.isValid (type.down ())) {
+          this.images += new Image (uri, name, type.down ());
         } else {
           // TODO: add an error message here
         }
@@ -243,7 +243,7 @@ public class MainWindow : Gtk.Window {
       }
 
       if (this.images.length > 0) {
-        this.set_list_window();
+        this.set_list_window ();
       }
 
       this.images = {};

--- a/src/Utils/Image.vala
+++ b/src/Utils/Image.vala
@@ -63,6 +63,17 @@ public class Image {
   }
 
   /**
+   * Convert a URI to a path.
+   *
+   * @param  string uri  URI e.g. "file:///home/user/Pictures/test_pr%C3%BCfen_%E3%83%86%E3%82%B9%E3%83%88_%E6%B5%8B%E8%AF%95.png"
+   * @return string?     Path e.g. "/home/user/Pictures/prüfen_测试.png" or null if no such file exists
+   */
+  public static string? to_path (string uri) {
+    var file = File.new_for_uri (uri);
+    return file.get_path ();
+  }
+
+  /**
    * Get file name from a path.
    *
    * @param  string path

--- a/src/Utils/Image.vala
+++ b/src/Utils/Image.vala
@@ -69,7 +69,7 @@ public class Image {
    * @return string
    */
   public static string getFileName (string path) {
-    var array = path.split("/");
+    var array = path.split ("/");
 
     return array[array.length - 1];
   }
@@ -81,7 +81,7 @@ public class Image {
    * @return string
    */
   public static string getFileType (string name) {
-    var array = name.split(".");
+    var array = name.split (".");
 
     return array[array.length - 1];
   }
@@ -136,6 +136,6 @@ public class Image {
   public static string calcSavings (float size, float new_size) {
     float savings = 100.00f - (new_size / size * 100.00f);
 
-    return "%.2f%%".printf(savings);
+    return "%.2f%%".printf (savings);
   }
 }

--- a/src/Utils/Image.vala
+++ b/src/Utils/Image.vala
@@ -92,7 +92,7 @@ public class Image {
    * @param  string type
    * @return bool
    */
-  public static bool isValid (string type) {
+  public static bool is_valid (string type) {
     string[] supported_types = {
       "png",
       "jpg",
@@ -100,7 +100,7 @@ public class Image {
       "bmp"
     };
 
-    return Utils.inArray (supported_types, type);
+    return Utils.in_array (supported_types, type);
   }
 
   /**
@@ -109,7 +109,7 @@ public class Image {
    * @param  int64 bytes
    * @return string
    */
-  public static string getUnit (int64 bytes) {
+  public static string get_unit (int64 bytes) {
     var unit = "";
 
     if (bytes > 1000 && bytes < 1000000) {
@@ -133,7 +133,7 @@ public class Image {
    * @param  float new_size
    * @return string
    */
-  public static string calcSavings (float size, float new_size) {
+  public static string calc_savings (float size, float new_size) {
     float savings = 100.00f - (new_size / size * 100.00f);
 
     return "%.2f%%".printf (savings);

--- a/src/Utils/Image.vala
+++ b/src/Utils/Image.vala
@@ -68,7 +68,7 @@ public class Image {
    * @param  string path
    * @return string
    */
-  public static string getFileName (string path) {
+  public static string get_file_name (string path) {
     var array = path.split ("/");
 
     return array[array.length - 1];
@@ -80,7 +80,7 @@ public class Image {
    * @param  string name
    * @return string
    */
-  public static string getFileType (string name) {
+  public static string get_file_type (string name) {
     var array = name.split (".");
 
     return array[array.length - 1];

--- a/src/Utils/JpegOptim.vala
+++ b/src/Utils/JpegOptim.vala
@@ -45,7 +45,7 @@ public class JpegOptim {
    * @return void
    */
   public void compress () throws Error {
-    var command = "jpegoptim " + Utils.join(" ", this.args);
+    var command = "jpegoptim " + Utils.join (" ", this.args);
 
     ThreadFunc<void*> run = () => {
       foreach (var image in this.images) {
@@ -55,14 +55,14 @@ public class JpegOptim {
 
         try {
           Process.spawn_command_line_sync (
-            command + " " + image.replace(" ", "\\ "),
+            command + " " + image.replace (" ", "\\ "),
             out stdout,
             out stderr,
             out status
           );
 
-          var new_size = this.getNewSize(stdout);
-          this.list.updateSize(image, new_size);
+          var new_size = this.getNewSize (stdout);
+          this.list.updateSize (image, new_size);
 
         } catch (SpawnError e) {
           warning ("Failed to spawn jpegoptim: %s", e.message);
@@ -72,7 +72,7 @@ public class JpegOptim {
       return null;
     };
 
-    new Thread<void*>.try("thread", (owned) run);
+    new Thread<void*>.try ("thread", (owned) run);
   }
 
   /**
@@ -83,9 +83,9 @@ public class JpegOptim {
    */
   public int getNewSize (string stdout) {
     // After the arrow and a space there should be the new size in bytes.
-    var text = stdout.split(" --> ")[1];
+    var text = stdout.split (" --> ")[1];
 
     // The first integer until a space should be the new size in bytes.
-    return int.parse(text.split(" ")[0]);
+    return int.parse (text.split (" ")[0]);
   }
 }

--- a/src/Utils/JpegOptim.vala
+++ b/src/Utils/JpegOptim.vala
@@ -35,7 +35,7 @@ public class JpegOptim {
    *
    * @return void
    */
-  public void addImage (string image) {
+  public void add_image (string image) {
     this.images += image;
   }
 

--- a/src/Utils/JpegOptim.vala
+++ b/src/Utils/JpegOptim.vala
@@ -61,8 +61,8 @@ public class JpegOptim {
             out status
           );
 
-          var new_size = this.getNewSize (stdout);
-          this.list.updateSize (image, new_size);
+          var new_size = this.get_new_size (stdout);
+          this.list.update_size (image, new_size);
 
         } catch (SpawnError e) {
           warning ("Failed to spawn jpegoptim: %s", e.message);
@@ -81,7 +81,7 @@ public class JpegOptim {
    * @param  string stdout
    * @return int
    */
-  public int getNewSize (string stdout) {
+  public int get_new_size (string stdout) {
     // After the arrow and a space there should be the new size in bytes.
     var text = stdout.split (" --> ")[1];
 

--- a/src/Utils/OptiPng.vala
+++ b/src/Utils/OptiPng.vala
@@ -45,7 +45,7 @@ public class OptiPng {
    * @return void
    */
   public void compress () throws Error {
-    var command = "optipng " + Utils.join(" ", this.args);
+    var command = "optipng " + Utils.join (" ", this.args);
 
     ThreadFunc<void*> run = () => {
       foreach (var image in this.images) {
@@ -55,7 +55,7 @@ public class OptiPng {
 
         try {
           Process.spawn_command_line_sync (
-            command + " " + image.replace(" ", "\\ "),
+            command + " " + image.replace (" ", "\\ "),
             out stderr,
             out stdout,
             out status
@@ -64,10 +64,10 @@ public class OptiPng {
           var new_size = 0;
 
           if (! stdout.contains ("is already optimized")) {
-            new_size = this.getNewSize(stdout);
+            new_size = this.getNewSize (stdout);
           }
 
-          this.list.updateSize(image, new_size);
+          this.list.updateSize (image, new_size);
         } catch (SpawnError e) {
           warning ("Failed to spawn optipng: %s", e.message);
         }
@@ -76,7 +76,7 @@ public class OptiPng {
       return null;
     };
 
-    new Thread<void*>.try("thread", (owned) run);
+    new Thread<void*>.try ("thread", (owned) run);
   }
 
   /**
@@ -87,9 +87,9 @@ public class OptiPng {
    */
   public int getNewSize (string stdout) {
     // After the piece of text and a space there should be the new size in bytes.
-    var text = stdout.split("Output file size = ")[1];
+    var text = stdout.split ("Output file size = ")[1];
 
     // The first integer until a space should be the new size in bytes.
-    return int.parse(text.split(" ")[0]);
+    return int.parse (text.split (" ")[0]);
   }
 }

--- a/src/Utils/OptiPng.vala
+++ b/src/Utils/OptiPng.vala
@@ -35,7 +35,7 @@ public class OptiPng {
    *
    * @return void
    */
-  public void addImage (string image) {
+  public void add_image (string image) {
     this.images += image;
   }
 

--- a/src/Utils/OptiPng.vala
+++ b/src/Utils/OptiPng.vala
@@ -64,10 +64,10 @@ public class OptiPng {
           var new_size = 0;
 
           if (! stdout.contains ("is already optimized")) {
-            new_size = this.getNewSize (stdout);
+            new_size = this.get_new_size (stdout);
           }
 
-          this.list.updateSize (image, new_size);
+          this.list.update_size (image, new_size);
         } catch (SpawnError e) {
           warning ("Failed to spawn optipng: %s", e.message);
         }
@@ -85,7 +85,7 @@ public class OptiPng {
    * @param  string stdout
    * @return int
    */
-  public int getNewSize (string stdout) {
+  public int get_new_size (string stdout) {
     // After the piece of text and a space there should be the new size in bytes.
     var text = stdout.split ("Output file size = ")[1];
 

--- a/src/Utils/Optimizer.vala
+++ b/src/Utils/Optimizer.vala
@@ -26,9 +26,9 @@ public class Optimizer {
     var optipng = new OptiPng (list);
 
     foreach (var image in this.images) {
-      if (Utils.inArray ({"jpg", "jpeg"}, image.type)) {
+      if (Utils.in_array ({"jpg", "jpeg"}, image.type)) {
         jpegoptim.addImage (image.path);
-      } else if (Utils.inArray ({"png", "bmp"}, image.type)) {
+      } else if (Utils.in_array ({"png", "bmp"}, image.type)) {
         optipng.addImage (image.path);
       }
     }

--- a/src/Utils/Optimizer.vala
+++ b/src/Utils/Optimizer.vala
@@ -27,9 +27,9 @@ public class Optimizer {
 
     foreach (var image in this.images) {
       if (Utils.in_array ({"jpg", "jpeg"}, image.type)) {
-        jpegoptim.addImage (image.path);
+        jpegoptim.add_image (image.path);
       } else if (Utils.in_array ({"png", "bmp"}, image.type)) {
-        optipng.addImage (image.path);
+        optipng.add_image (image.path);
       }
     }
 

--- a/src/Utils/Utils.vala
+++ b/src/Utils/Utils.vala
@@ -5,7 +5,7 @@ public class Utils {
    *
    * @return bool
    */
-  public static bool inArray (string[] haystack, string needle) {
+  public static bool in_array (string[] haystack, string needle) {
     foreach (var item in haystack) {
       if (item == needle) {
         return true;

--- a/src/Widgets/List.vala
+++ b/src/Widgets/List.vala
@@ -18,12 +18,12 @@ public class List {
 
     listmodel = new Gtk.ListStore (6, typeof (bool), typeof (int), typeof (string), typeof (string), typeof (string), typeof (string));
 
-    this.upload_button = new Gtk.Button.with_label("+");
-    this.upload_button.get_style_context().add_class("upload_button");
-    this.upload_button.get_style_context().add_class("add");
-    this.upload_button.set_valign(Gtk.Align.START);
-    this.upload_button.set_halign(Gtk.Align.END);
-    ((Gtk.Widget) this.upload_button).set_focus_on_click(false);
+    this.upload_button = new Gtk.Button.with_label ("+");
+    this.upload_button.get_style_context ().add_class ("upload_button");
+    this.upload_button.get_style_context ().add_class ("add");
+    this.upload_button.set_valign (Gtk.Align.START);
+    this.upload_button.set_halign (Gtk.Align.END);
+    ((Gtk.Widget) this.upload_button).set_focus_on_click (false);
 
     Gtk.TreeIter iter;
     foreach (var image in this.images) {
@@ -32,7 +32,7 @@ public class List {
                     0, true,
                     1, 1,
                     2, image.name,
-                    3, Image.getUnit(image.size),
+                    3, Image.getUnit (image.size),
                     4, "",
                     5, "");
     }
@@ -98,7 +98,7 @@ public class List {
       }
     }
 
-    Gtk.TreePath tree_path = new Gtk.TreePath.from_string (key.to_string());
+    Gtk.TreePath tree_path = new Gtk.TreePath.from_string (key.to_string ());
     bool tmp = this.listmodel.get_iter (out iter, tree_path);
     assert (tmp == true);
 
@@ -108,7 +108,7 @@ public class List {
               2, image.name,
               3, Image.getUnit (image.size),
               4, Image.getUnit (image.new_size),
-              5, Image.calcSavings((float) image.size, (float) image.new_size));
+              5, Image.calcSavings ((float) image.size, (float) image.new_size));
   }
 
   public void updateTreeView (Image[] images) {
@@ -128,7 +128,7 @@ public class List {
                       0, true,
                       1, 1,
                       2, image.name,
-                      3, Image.getUnit(image.size),
+                      3, Image.getUnit (image.size),
                       4, "",
                       5, "");
       }

--- a/src/Widgets/List.vala
+++ b/src/Widgets/List.vala
@@ -32,7 +32,7 @@ public class List {
                     0, true,
                     1, 1,
                     2, image.name,
-                    3, Image.getUnit (image.size),
+                    3, Image.get_unit (image.size),
                     4, "",
                     5, "");
     }
@@ -48,29 +48,29 @@ public class List {
     var spinner = new Gtk.CellRendererSpinner ();
 
     Gtk.TreeViewColumn column = new Gtk.TreeViewColumn ();
-		column.set_title ("");
-		column.pack_start (spinner, false);
-		column.add_attribute (spinner, "active", 0);
-		column.add_attribute (spinner, "pulse", 1);
-		view.append_column (column);
+    column.set_title ("");
+    column.pack_start (spinner, false);
+    column.add_attribute (spinner, "active", 0);
+    column.add_attribute (spinner, "pulse", 1);
+    view.append_column (column);
 
     view.insert_column_with_attributes (2, _("File"), cell, "text", 2);
-		view.insert_column_with_attributes (3, _("Size"), cell, "text", 3);
-		view.insert_column_with_attributes (4, _("New size"), cell, "text", 4);
+    view.insert_column_with_attributes (3, _("Size"), cell, "text", 3);
+    view.insert_column_with_attributes (4, _("New size"), cell, "text", 4);
     view.insert_column_with_attributes (5, _("Savings"), cell, "text", 5);
 
     // Rotate the spinner:
-		Timeout.add (50, () => {
-			listmodel.foreach ((model, path, iter) => {
-				Value val;
-				listmodel.get_value (iter, 1, out val);
-				val.set_int (val.get_int () + 1);
+    Timeout.add (50, () => {
+      listmodel.foreach ((model, path, iter) => {
+        Value val;
+        listmodel.get_value (iter, 1, out val);
+        val.set_int (val.get_int () + 1);
         listmodel.set_value (iter, 1, val);
 
-				return false;
+        return false;
       });
 
-			return true;
+      return true;
     });
 
     var optimizer = new Optimizer (this.images);
@@ -79,7 +79,7 @@ public class List {
     return main;
   }
 
-  public void updateSize (string path, int size) {
+  public void update_size (string path, int size) {
     // Update image with new attributes
     for (var i = 0; i < this.images.length; i++) {
       if (this.images[i].path == path) {
@@ -88,7 +88,7 @@ public class List {
     }
 
     Gtk.TreeIter iter;
-    Image image = new Image("", "", "");
+    Image image = new Image ("", "", "");
     var key = 0;
     for (var i = 0; i < this.images.length; i++) {
       if (this.images[i].path == path) {
@@ -106,12 +106,12 @@ public class List {
               0, false,
               1, 1,
               2, image.name,
-              3, Image.getUnit (image.size),
-              4, Image.getUnit (image.new_size),
-              5, Image.calcSavings ((float) image.size, (float) image.new_size));
+              3, Image.get_unit (image.size),
+              4, Image.get_unit (image.new_size),
+              5, Image.calc_savings ((float) image.size, (float) image.new_size));
   }
 
-  public void updateTreeView (Image[] images) {
+  public void update_tree_view (Image[] images) {
     Gtk.TreeIter iter;
 
     foreach (var image in images) {
@@ -128,7 +128,7 @@ public class List {
                       0, true,
                       1, 1,
                       2, image.name,
-                      3, Image.getUnit (image.size),
+                      3, Image.get_unit (image.size),
                       4, "",
                       5, "");
       }

--- a/src/Widgets/UploadScreen.vala
+++ b/src/Widgets/UploadScreen.vala
@@ -6,42 +6,42 @@ public class UploadScreen : Gtk.Box {
 
   public Gtk.Box window() {
     this.border_width = 10;
-    this.get_style_context().add_class("main");
+    this.get_style_context ().add_class ("main");
 
-    var upload_area = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-    upload_area.set_spacing(15);
-    upload_area.set_valign(Gtk.Align.CENTER);
-    upload_area.set_halign(Gtk.Align.CENTER);
+    var upload_area = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+    upload_area.set_spacing (15);
+    upload_area.set_valign (Gtk.Align.CENTER);
+    upload_area.set_halign (Gtk.Align.CENTER);
 
     Gtk.Image icon = new Gtk.Image();
 
     try {
-      var icon_pixbuf = new Gdk.Pixbuf.from_file_at_scale("/usr/share/icons/hicolor/scalable/apps/upload_icon.svg", 64, 64, true);
-      icon = new Gtk.Image.from_pixbuf(icon_pixbuf);
+      var icon_pixbuf = new Gdk.Pixbuf.from_file_at_scale ("/usr/share/icons/hicolor/scalable/apps/upload_icon.svg", 64, 64, true);
+      icon = new Gtk.Image.from_pixbuf (icon_pixbuf);
     } catch (Error e) {}
 
-    var title = new Gtk.Label(_("Drag and drop images here"));
-    title.get_style_context().add_class("h1");
+    var title = new Gtk.Label (_("Drag and drop images here"));
+    title.get_style_context ().add_class ("h1");
 
-    var otherwise = new Gtk.Label(_("or"));
-    otherwise.get_style_context().add_class("h4");
+    var otherwise = new Gtk.Label (_("or"));
+    otherwise.get_style_context ().add_class ("h4");
 
-    this.upload_button = new Gtk.Button.with_label(_("Browse files"));
-    this.upload_button.get_style_context().add_class ("suggested-action");
-    this.upload_button.get_style_context().add_class("upload_button");
-    this.upload_button.set_valign(Gtk.Align.CENTER);
-    this.upload_button.set_halign(Gtk.Align.CENTER);
-    ((Gtk.Widget) this.upload_button).set_focus_on_click(false);
+    this.upload_button = new Gtk.Button.with_label (_("Browse files"));
+    this.upload_button.get_style_context ().add_class ("suggested-action");
+    this.upload_button.get_style_context ().add_class ("upload_button");
+    this.upload_button.set_valign (Gtk.Align.CENTER);
+    this.upload_button.set_halign (Gtk.Align.CENTER);
+    ((Gtk.Widget) this.upload_button).set_focus_on_click (false);
 
     if (icon != null) {
-      upload_area.pack_start(icon, false, false, 0);
+      upload_area.pack_start (icon, false, false, 0);
     }
 
-    upload_area.pack_start(title, false, false, 0);
-    upload_area.pack_start(otherwise, false, false, 0);
-    upload_area.pack_start(this.upload_button, false, false, 0);
+    upload_area.pack_start (title, false, false, 0);
+    upload_area.pack_start (otherwise, false, false, 0);
+    upload_area.pack_start (this.upload_button, false, false, 0);
 
-    pack_start(upload_area);
+    pack_start (upload_area);
 
     return this;
   }

--- a/src/Widgets/UploadScreen.vala
+++ b/src/Widgets/UploadScreen.vala
@@ -4,7 +4,7 @@ public class UploadScreen : Gtk.Box {
 
   public Gtk.Button upload_button;
 
-  public Gtk.Box window() {
+  public Gtk.Box window () {
     this.border_width = 10;
     this.get_style_context ().add_class ("main");
 
@@ -13,7 +13,7 @@ public class UploadScreen : Gtk.Box {
     upload_area.set_valign (Gtk.Align.CENTER);
     upload_area.set_halign (Gtk.Align.CENTER);
 
-    Gtk.Image icon = new Gtk.Image();
+    Gtk.Image icon = new Gtk.Image ();
 
     try {
       var icon_pixbuf = new Gdk.Pixbuf.from_file_at_scale ("/usr/share/icons/hicolor/scalable/apps/upload_icon.svg", 64, 64, true);


### PR DESCRIPTION
Fixes #24

- Correct the way to convert a URI to a path
- Do not try to convert to a path if a variable is already a path
- Do not name 'uri' if a variable contains a path