### PR TITLE
Fix Ctrl + Q not working when opening the app with files

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -10,11 +10,8 @@ class Application : Granite.Application {
         flags: GLib.ApplicationFlags.HANDLES_OPEN);
   }
 
-  protected override void activate () {
-    if (this.app_window == null) {
-      this.app_window = new MainWindow (this);
-      this.app_window.show_all ();
-    }
+  protected override void startup () {
+    base.startup ();
 
     var quit_action = new SimpleAction ("quit", null);
 
@@ -26,6 +23,13 @@ class Application : Granite.Application {
         this.app_window.destroy ();
       }
     });
+  }
+
+  protected override void activate () {
+    if (this.app_window == null) {
+      this.app_window = new MainWindow (this);
+      this.app_window.show_all ();
+    }
   }
 
   public override void open (File[] files, string hint) {


### PR DESCRIPTION
Fixes the Ctrl + Q hotkey not working when the app launches through the `open (File[] files, string hint)` method, i.e.:

- when you launch the app with images in the command line arguments, i.e. `flatpak run com.github.gijsgoudzwaard.image-optimizer /home/user/Pictures/image.png`
- when you launch the app from the "Open with" menu (#76)