### PR TITLE
Application: Remove unused using, deprecations, and Gtk.init

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,6 +1,4 @@
-using Granite.Widgets;
-
-class Application : Granite.Application {
+class Application : Gtk.Application {
 
   private Image[] images = {};
   private MainWindow app_window;
@@ -53,7 +51,6 @@ class Application : Granite.Application {
   }
 
   public static int main (string[] args) {
-    Gtk.init (ref args);
     var app = new Application ();
     return app.run (args);
   }


### PR DESCRIPTION
- Remove unused using
- Replace deprecated `Granite.Application` with `Gtk.Application`
  - From [Valadoc](https://valadoc.org/granite/Granite.Application.html):
    - `Warning: Application is deprecated since 0.5.0. Use Gtk.Application.`
- Remove `Gtk.init` which is not necessary when using `Gtk.Application`
  - From [Valadoc](https://valadoc.org/gtk+-3.0/Gtk.init.html):
    - `And if you are using Application, you don't have to call any of the initialization functions either; the startup handler does it for you.`