### PR TITLE
Load custom icons from GResource instead of the absolute path

### DIFF
--- a/data/com.github.gijsgoudzwaard.image-optimizer.gresource.xml
+++ b/data/com.github.gijsgoudzwaard.image-optimizer.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/com/github/gijsgoudzwaard/image-optimizer">
-    
+  <gresource prefix="/com/github/gijsgoudzwaard/image-optimizer/icons">
+    <file compressed="true" preprocess="xml-stripblanks" alias="upload_icon.svg">icons/upload_icon.svg</file>
   </gresource>
 </gresources>

--- a/data/meson.build
+++ b/data/meson.build
@@ -11,11 +11,6 @@ foreach i : icon_sizes
     )
 endforeach
 
-install_data(
-    join_paths('icons', 'upload_icon.svg'),
-    install_dir: 'share/icons/hicolor/scalable/apps'
-)
-
 i18n.merge_file(
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',

--- a/src/Widgets/UploadScreen.vala
+++ b/src/Widgets/UploadScreen.vala
@@ -13,12 +13,7 @@ public class UploadScreen : Gtk.Box {
     upload_area.set_valign (Gtk.Align.CENTER);
     upload_area.set_halign (Gtk.Align.CENTER);
 
-    Gtk.Image icon = new Gtk.Image ();
-
-    try {
-      var icon_pixbuf = new Gdk.Pixbuf.from_file_at_scale ("/usr/share/icons/hicolor/scalable/apps/upload_icon.svg", 64, 64, true);
-      icon = new Gtk.Image.from_pixbuf (icon_pixbuf);
-    } catch (Error e) {}
+    var icon = new Gtk.Image.from_resource ("/com/github/gijsgoudzwaard/image-optimizer/icons/upload_icon.svg");
 
     var title = new Gtk.Label (_("Drag and drop images here"));
     title.get_style_context ().add_class ("h1");
@@ -33,10 +28,7 @@ public class UploadScreen : Gtk.Box {
     this.upload_button.set_halign (Gtk.Align.CENTER);
     ((Gtk.Widget) this.upload_button).set_focus_on_click (false);
 
-    if (icon != null) {
-      upload_area.pack_start (icon, false, false, 0);
-    }
-
+    upload_area.pack_start (icon, false, false, 0);
     upload_area.pack_start (title, false, false, 0);
     upload_area.pack_start (otherwise, false, false, 0);
     upload_area.pack_start (this.upload_button, false, false, 0);


### PR DESCRIPTION
The location where the custom icons are stored depends on the prefix path specified to meson. Especially, it's "/app" instead of "/usr" in case of Flatpak. So, provide the icons through GResource instead.

This fixes the `upload_icon.svg` is not displayed in the Flatpak version of the app.

## Before
![スクリーンショット 2024-09-29 08 09 56](https://github.com/user-attachments/assets/5988ff42-dd2d-463d-988b-c8405f0e558a)

## After
![スクリーンショット 2024-09-29 08 09 13](https://github.com/user-attachments/assets/2e1e7431-468a-4f7d-983a-d331ef6dc3e5)
