### PR TITLE
meson: Replace deprecated source_root with project_source_root

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -19,7 +19,7 @@ install_data(
 i18n.merge_file(
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: join_paths(meson.project_source_root(), 'po', 'extra'),
     type: 'desktop',
     install: true,
     install_dir: join_paths(get_option('datadir'), 'applications')
@@ -28,7 +28,7 @@ i18n.merge_file(
 i18n.merge_file(
     input: meson.project_name() + '.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: join_paths(meson.project_source_root(), 'po', 'extra'),
     install: true,
     install_dir: join_paths(get_option('datadir'), 'metainfo')
 )

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: libgtk-3-dev,
                libgranite-dev,
                debhelper (>= 9),
                valac,
-               meson
+               meson (>= 0.56.0)
 Standards-Version: 3.9.6
 
 Package: com.github.gijsgoudzwaard.image-optimizer

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
-project('com.github.gijsgoudzwaard.image-optimizer', 'vala', 'c')
+project('com.github.gijsgoudzwaard.image-optimizer', 'vala', 'c',
+  meson_version: '>= 0.56.0')
 
 gnome = import('gnome')
 i18n = import('i18n')

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,6 +1,6 @@
 i18n.gettext('extra',
   args: [
-    '--directory=' + meson.source_root(),
+    '--directory=' + meson.project_source_root(),
     '--from-code=UTF-8'
   ],
   install: false

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,6 +1,6 @@
 i18n.gettext(meson.project_name(),
   args: [
-    '--directory=' + meson.source_root(),
+    '--directory=' + meson.project_source_root(),
     '--from-code=UTF-8'
   ]
 )


### PR DESCRIPTION
`meson.source_root()` was deprecated in 0.56.0, so replace it with `meson.project_source_root`.

See also: https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonsource_root