### PR TITLE
Flatpak: Update optipng to 7.9.1

### DIFF
--- a/com.github.gijsgoudzwaard.image-optimizer.yml
+++ b/com.github.gijsgoudzwaard.image-optimizer.yml
@@ -36,8 +36,9 @@ modules:
       - --with-system-libs
     sources:
       - type: archive
-        url: https://netcologne.dl.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8.tar.gz
-        sha256: 25a3bd68481f21502ccaa0f4c13f84dcf6b20338e4c4e8c51f2cefbd8513398c
+        url: https://sourceforge.net/projects/optipng/files/OptiPNG/optipng-7.9.1/optipng-7.9.1.tar.gz/download
+        sha256: c2579be58c2c66dae9d63154edcb3d427fef64cb00ec0aff079c9d156ec46f29
+        dest-filename: optipng.tar.gz
   - name: image-optimizer
     buildsystem: meson
     sources:


### PR DESCRIPTION
Backport of https://github.com/flathub/com.github.gijsgoudzwaard.image-optimizer/pull/13
