### PR TITLE
Use GLib.format_size instead of own method

### DIFF
--- a/po/aa.po
+++ b/po/aa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ab.po
+++ b/po/ab.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ae.po
+++ b/po/ae.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ak.po
+++ b/po/ak.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/am.po
+++ b/po/am.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/an.po
+++ b/po/an.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/as.po
+++ b/po/as.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/av.po
+++ b/po/av.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ay.po
+++ b/po/ay.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ba.po
+++ b/po/ba.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,39 +15,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/bh.po
+++ b/po/bh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/bi.po
+++ b/po/bi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/bm.po
+++ b/po/bm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/bo.po
+++ b/po/bo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/br.po
+++ b/po/br.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ce.po
+++ b/po/ce.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ch.po
+++ b/po/ch.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/co.po
+++ b/po/co.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/com.github.gijsgoudzwaard.image-optimizer.pot
+++ b/po/com.github.gijsgoudzwaard.image-optimizer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/cr.po
+++ b/po/cr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/cu.po
+++ b/po/cu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/cv.po
+++ b/po/cv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/cy.po
+++ b/po/cy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2020-03-09 19:23+0100\n"
 "Last-Translator: Finn (0xhtml)\n"
 "Language-Team: none\n"
@@ -17,37 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr "Bild hinzufügen"
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Bild(er) auswählen"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Schließen"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Öffnen"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr "kB"
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr "MB"
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr "Bytes"
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -65,14 +45,29 @@ msgstr "Neue Größe"
 msgid "Savings"
 msgstr "Ersparnis"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Bilder hier per Drag & Drop ablegen"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr "oder"
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Datein durchsuchen"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Schließen"
+
+#~ msgid "_Open"
+#~ msgstr "_Öffnen"
+
+#~ msgid "kb"
+#~ msgstr "kB"
+
+#~ msgid "mb"
+#~ msgstr "MB"
+
+#~ msgid "bytes"
+#~ msgstr "Bytes"

--- a/po/dv.po
+++ b/po/dv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/dz.po
+++ b/po/dz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ee.po
+++ b/po/ee.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,37 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Select image(s)"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Cancel"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Open"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr ""
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -65,14 +45,20 @@ msgstr "New size"
 msgid "Savings"
 msgstr "Savings"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Drag and drop images here"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Browse files"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Cancel"
+
+#~ msgid "_Open"
+#~ msgstr "_Open"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,37 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Select image(s)"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Cancel"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Open"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr ""
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -65,14 +45,20 @@ msgstr "New size"
 msgid "Savings"
 msgstr "Savings"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Drag and drop images here"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Browse files"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Cancel"
+
+#~ msgid "_Open"
+#~ msgstr "_Open"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,37 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Select image(s)"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Cancel"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Open"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr ""
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -65,14 +45,20 @@ msgstr "New size"
 msgid "Savings"
 msgstr "Savings"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Drag and drop images here"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Browse files"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Cancel"
+
+#~ msgid "_Open"
+#~ msgstr "_Open"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ff.po
+++ b/po/ff.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/fj.po
+++ b/po/fj.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/fo.po
+++ b/po/fo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: NathanBnm\n"
 "Language-Team: Français\n"
@@ -17,37 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Optimiseur d'image"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr "Ajouter une image"
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Sélectionnez des images"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Annuler"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Ouvrir"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr "ko"
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr "mo"
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr "octets"
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -65,14 +45,29 @@ msgstr "Nouvelle taille"
 msgid "Savings"
 msgstr "Économie"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Glissez-déposez des images ici"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr "ou"
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Parcourir"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Annuler"
+
+#~ msgid "_Open"
+#~ msgstr "_Ouvrir"
+
+#~ msgid "kb"
+#~ msgstr "ko"
+
+#~ msgid "mb"
+#~ msgstr "mo"
+
+#~ msgid "bytes"
+#~ msgstr "octets"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/fy.po
+++ b/po/fy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/gd.po
+++ b/po/gd.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/gn.po
+++ b/po/gn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/gv.po
+++ b/po/gv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ha.po
+++ b/po/ha.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ho.po
+++ b/po/ho.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,39 +15,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ht.po
+++ b/po/ht.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/hy.po
+++ b/po/hy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/hz.po
+++ b/po/hz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ia.po
+++ b/po/ia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ie.po
+++ b/po/ie.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ig.po
+++ b/po/ig.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ii.po
+++ b/po/ii.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ik.po
+++ b/po/ik.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/io.po
+++ b/po/io.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/is.po
+++ b/po/is.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-09-02 13:49+0100\n"
 "Last-Translator: Mirko Brombin <send@mirko.pm>\n"
 "Language-Team: none\n"
@@ -17,37 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr "Aggiungi immagine"
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Seleziona immagini"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Annulla"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Apri"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr "kb"
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr "mb"
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr "bytes"
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -65,14 +45,29 @@ msgstr "Nuova dimensione"
 msgid "Savings"
 msgstr "Salvando"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Sposta le immagini qui"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr "o"
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Seleziona i file"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Annulla"
+
+#~ msgid "_Open"
+#~ msgstr "_Apri"
+
+#~ msgid "kb"
+#~ msgstr "kb"
+
+#~ msgid "mb"
+#~ msgstr "mb"
+
+#~ msgid "bytes"
+#~ msgstr "bytes"

--- a/po/iu.po
+++ b/po/iu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/jv.po
+++ b/po/jv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kg.po
+++ b/po/kg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ki.po
+++ b/po/ki.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kj.po
+++ b/po/kj.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kl.po
+++ b/po/kl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/km.po
+++ b/po/km.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kn.po
+++ b/po/kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kr.po
+++ b/po/kr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ks.po
+++ b/po/ks.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ku.po
+++ b/po/ku.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kv.po
+++ b/po/kv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/kw.po
+++ b/po/kw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ky.po
+++ b/po/ky.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/la.po
+++ b/po/la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/lb.po
+++ b/po/lb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/lg.po
+++ b/po/lg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/li.po
+++ b/po/li.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ln.po
+++ b/po/ln.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/lo.po
+++ b/po/lo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,39 +15,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
-"%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/lu.po
+++ b/po/lu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,36 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mg.po
+++ b/po/mg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mh.po
+++ b/po/mh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mi.po
+++ b/po/mi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mk.po
+++ b/po/mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ml.po
+++ b/po/ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mn.po
+++ b/po/mn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mo.po
+++ b/po/mo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/mt.po
+++ b/po/mt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/my.po
+++ b/po/my.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/na.po
+++ b/po/na.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/nd.po
+++ b/po/nd.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ne.po
+++ b/po/ne.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ng.po
+++ b/po/ng.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/nr.po
+++ b/po/nr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/nv.po
+++ b/po/nv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ny.po
+++ b/po/ny.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/oj.po
+++ b/po/oj.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/om.po
+++ b/po/om.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/or.po
+++ b/po/or.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/os.po
+++ b/po/os.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/pi.po
+++ b/po/pi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-12-12 17:08+0100\n"
 "Last-Translator: Michał Nowakowski <nowakowski@offshore.rocks>\n"
 "Language-Team:\n"
@@ -16,37 +16,17 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr "Dodaj obraz"
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Wybierz obraz(y)"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Anuluj"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Otwórz"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr "kb"
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr "mb"
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr "bajtów"
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -64,14 +44,29 @@ msgstr "Nowy rozmiar"
 msgid "Savings"
 msgstr "Optymalizacja"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Przeciągnij i upuść obrazy tutaj"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr "albo"
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Przeglądaj pliki"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Anuluj"
+
+#~ msgid "_Open"
+#~ msgstr "_Otwórz"
+
+#~ msgid "kb"
+#~ msgstr "kb"
+
+#~ msgid "mb"
+#~ msgstr "mb"
+
+#~ msgid "bytes"
+#~ msgstr "bajtów"

--- a/po/ps.po
+++ b/po/ps.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2020-08-26 15:06+0100\n"
 "Last-Translator: André Barata <andretiagob@protonmail.com>\n"
 "Language-Team: none\n"
@@ -18,37 +18,17 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr "Adicionar Imagem"
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Selecionar Imagem(s)"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Cancelar"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Abrir"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr "kb"
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr "mb"
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr "bytes"
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -66,14 +46,29 @@ msgstr "Novo tamanho"
 msgid "Savings"
 msgstr "Ganhos"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Arraste e solte as imagens aqui"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr "ou"
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Procurar ficheiros"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Cancelar"
+
+#~ msgid "_Open"
+#~ msgstr "_Abrir"
+
+#~ msgid "kb"
+#~ msgstr "kb"
+
+#~ msgid "mb"
+#~ msgstr "mb"
+
+#~ msgid "bytes"
+#~ msgstr "bytes"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/qu.po
+++ b/po/qu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/rm.po
+++ b/po/rm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/rn.po
+++ b/po/rn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,36 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,39 +15,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/rue.po
+++ b/po/rue.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/rw.po
+++ b/po/rw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sa.po
+++ b/po/sa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sc.po
+++ b/po/sc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sd.po
+++ b/po/sd.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/se.po
+++ b/po/se.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sg.po
+++ b/po/sg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,39 +15,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sm.po
+++ b/po/sm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sma.po
+++ b/po/sma.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sn.po
+++ b/po/sn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/so.po
+++ b/po/so.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,39 +15,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -66,14 +46,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ss.po
+++ b/po/ss.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/st.po
+++ b/po/st.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/su.po
+++ b/po/su.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/sw.po
+++ b/po/sw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/tg.po
+++ b/po/tg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ti.po
+++ b/po/ti.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/tk.po
+++ b/po/tk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/tl.po
+++ b/po/tl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/tn.po
+++ b/po/tn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/to.po
+++ b/po/to.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Şafak Genişol\n"
 "Language-Team: none\n"
@@ -17,37 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr "Resim ekle"
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Resim seç(s)"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_İptal"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Aç"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr "kb"
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr "mb"
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr "bytes"
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -65,14 +45,29 @@ msgstr "Yeni boyut"
 msgid "Savings"
 msgstr "Kaydediliyor"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Resimleri buraya sürükleyip bırakın"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr "veya"
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Dosyalara göz at"
+
+#~ msgid "_Cancel"
+#~ msgstr "_İptal"
+
+#~ msgid "_Open"
+#~ msgstr "_Aç"
+
+#~ msgid "kb"
+#~ msgstr "kb"
+
+#~ msgid "mb"
+#~ msgstr "mb"
+
+#~ msgid "bytes"
+#~ msgstr "bytes"

--- a/po/ts.po
+++ b/po/ts.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/tt.po
+++ b/po/tt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/tw.po
+++ b/po/tw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ty.po
+++ b/po/ty.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-08-08 15:26+0300\n"
 "Last-Translator: Igor Gordiichuk <igor_ck@outlook.com>\n"
 "Language-Team: Ukrainian <igor_ck@outlook.com>\n"
@@ -16,41 +16,21 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
-"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : "
+"n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2\n"
 "X-Generator: Gtranslator 3.32.1\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr "Image Optimizer"
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr "Додати зображення"
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
 msgstr "Вибрати зображення"
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr "_Скасувати"
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr "_Відкрити"
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr "кБ"
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr "мБ"
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
-msgstr "байт"
 
 #: src/Widgets/List.vala:57
 msgid "File"
@@ -68,14 +48,29 @@ msgstr "Новий розмір"
 msgid "Savings"
 msgstr "Заощаджено"
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr "Перетягнути зображення сюди"
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr "або"
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr "Вибрати файли"
+
+#~ msgid "_Cancel"
+#~ msgstr "_Скасувати"
+
+#~ msgid "_Open"
+#~ msgstr "_Відкрити"
+
+#~ msgid "kb"
+#~ msgstr "кБ"
+
+#~ msgid "mb"
+#~ msgstr "мБ"
+
+#~ msgid "bytes"
+#~ msgstr "байт"

--- a/po/ur.po
+++ b/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/uz.po
+++ b/po/uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/ve.po
+++ b/po/ve.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,36 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -65,14 +45,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/vo.po
+++ b/po/vo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/wa.po
+++ b/po/wa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/wo.po
+++ b/po/wo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/xh.po
+++ b/po/xh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/yi.po
+++ b/po/yi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/yo.po
+++ b/po/yo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/za.po
+++ b/po/za.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/po/zu.po
+++ b/po/zu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.gijsgoudzwaard.image-optimizer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-27 08:17+0100\n"
+"POT-Creation-Date: 2026-04-25 22:04+0900\n"
 "PO-Revision-Date: 2019-03-26 13:49+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,36 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:54
+#: src/MainWindow.vala:44
 msgid "Image Optimizer"
 msgstr ""
 
-#: src/MainWindow.vala:129
+#: src/MainWindow.vala:119
 msgid "Add Image"
 msgstr ""
 
-#: src/MainWindow.vala:218
+#: src/MainWindow.vala:202
 msgid "Select image(s)"
-msgstr ""
-
-#: src/MainWindow.vala:220
-msgid "_Cancel"
-msgstr ""
-
-#: src/MainWindow.vala:221
-msgid "_Open"
-msgstr ""
-
-#: src/Utils/Image.vala:115
-msgid "kb"
-msgstr ""
-
-#: src/Utils/Image.vala:118
-msgid "mb"
-msgstr ""
-
-#: src/Utils/Image.vala:120
-msgid "bytes"
 msgstr ""
 
 #: src/Widgets/List.vala:57
@@ -64,14 +44,14 @@ msgstr ""
 msgid "Savings"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:23
+#: src/Widgets/UploadScreen.vala:24
 msgid "Drag and drop images here"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:26
+#: src/Widgets/UploadScreen.vala:27
 msgid "or"
 msgstr ""
 
-#: src/Widgets/UploadScreen.vala:29
+#: src/Widgets/UploadScreen.vala:30
 msgid "Browse files"
 msgstr ""

--- a/src/Utils/Image.vala
+++ b/src/Utils/Image.vala
@@ -115,28 +115,6 @@ public class Image {
   }
 
   /**
-   * Get size in bytes and return in proper units (bytes, KB, MB).
-   *
-   * @param  int64 bytes
-   * @return string
-   */
-  public static string get_unit (int64 bytes) {
-    var unit = "";
-
-    if (bytes > 1000 && bytes < 1000000) {
-      var size = "%.2f".printf (((double) bytes) / 1000);
-      unit = size.to_string ().replace (".", ",") + " " + _("kb");
-    } else if (bytes > 1000000) {
-      var size = "%.2f".printf (((double) bytes) / 1000000);
-      unit = size.to_string ().replace (".", ",") + " " + _("mb");
-    } else {
-      unit = bytes.to_string () + " " + _("bytes");
-    }
-
-    return unit;
-  }
-
-  /**
    * Calculate the savings from the new size compared to the old size.
    * Returns a percentage.
    *

--- a/src/Widgets/List.vala
+++ b/src/Widgets/List.vala
@@ -32,7 +32,7 @@ public class List {
                     0, true,
                     1, 1,
                     2, image.name,
-                    3, Image.get_unit (image.size),
+                    3, GLib.format_size (image.size),
                     4, "",
                     5, "");
     }
@@ -106,8 +106,8 @@ public class List {
               0, false,
               1, 1,
               2, image.name,
-              3, Image.get_unit (image.size),
-              4, Image.get_unit (image.new_size),
+              3, GLib.format_size (image.size),
+              4, GLib.format_size (image.new_size),
               5, Image.calc_savings ((float) image.size, (float) image.new_size));
   }
 
@@ -128,7 +128,7 @@ public class List {
                       0, true,
                       1, 1,
                       2, image.name,
-                      3, Image.get_unit (image.size),
+                      3, GLib.format_size (image.size),
                       4, "",
                       5, "");
       }


### PR DESCRIPTION
### Changes Summary
- Use `GLib.format_size()` instead of own method: ec5ea6c791751b5c4065e9e5a812bdf05c7ba086
- Update translation files: 37a87119b653b75c9df6da157f804a35c419a25a

### Pros & Cons
- This lessens code and plus allows us to use correct delimiter for the system locale
- It does not seem to have an interface to specify which digit to be rounded at
  - So, "Size" and "New size" possibly show the same size even if "Savings" indicates over 0.00%

### Before
<img width="1034" height="736" alt="image" src="https://github.com/user-attachments/assets/edd128a2-5f38-4455-8733-9c751bfbc9af" />

### After
<img width="1034" height="736" alt="image" src="https://github.com/user-attachments/assets/25c76f24-0378-49db-9d90-d8044c13cbb6" />
