### PR TITLE
Portal permissions

### DIFF
--- a/.github/scripts/regression-test.sh
+++ b/.github/scripts/regression-test.sh
@@ -13,7 +13,8 @@
 #   R7  no diagnostics for input that is perfectly fine.
 #   R8  Ctrl+Q, which the app description promises.
 #   R9  a bmp, which the app used to accept and then not optimize.
-#   R10 a file that cannot be rewritten, which used to report a fake saving.
+#   R10 a read-only directory, which the copy-and-write-back path has to survive.
+#   R11 a read-only file, which has to fail without inventing a saving.
 #
 # Usage, against an installed tree:
 #
@@ -327,34 +328,51 @@ check "the file is unchanged" "$(cmp -s "$BMP_SOURCE" "$r9/photo.bmp" && echo ye
 check "files in the directory" "$(find "$r9" -type f | wc -l | tr -d ' ')" "1"
 stop_app
 
-echo "### R10 a file that cannot be rewritten is reported as unchanged ###"
-# Both optimizers replace a file by writing a temporary one next to it and
-# renaming, so a directory they cannot write to fails the whole operation. What
-# made that dangerous is that jpegoptim still prints "11261 --> 11067 bytes,
-# optimized." on stdout before it tries, and the app used to parse that line
-# without looking at the exit status. The row then claimed a saving on a file
-# that was untouched. This is also what a document portal path behaves like.
+echo "### R10 a read-only directory no longer stops the optimization ###"
+# The optimizers replace a file by writing a temporary one beside it and
+# renaming, so they need write access to the directory. The app now hands them a
+# copy inside its own runtime directory and writes the result back over the
+# original file descriptor, which only needs write access to the file. A
+# directory the user cannot write to therefore has to work, and that is the same
+# shape as a document portal path, where the grant covers one file and nothing
+# around it.
 if [ "$(id -u)" = "0" ]; then
-  # root is exempt from directory permissions, so the write succeeds and the case
-  # proves nothing. CI runs the suite as an ordinary user, where it does apply.
-  echo "  SKIP running as root, which ignores directory permissions"
+  # root is exempt from these permissions, so the case would pass for the wrong
+  # reason. CI runs the suite as an ordinary user, where it applies.
+  echo "  SKIP running as root, which ignores file and directory permissions"
 else
   r10="$WORK/r10"
   mkdir -p "$r10"
-  cp "$PNG_SOURCE" "$r10/locked.png"
-  cp "$JPG_SOURCE" "$r10/locked.jpg"
+  cp "$PNG_SOURCE" "$r10/locked-dir.png"
+  cp "$JPG_SOURCE" "$r10/locked-dir.jpg"
   record "$r10"/*
   chmod a-w "$r10"
-  start_app "" "$r10/locked.png" "$r10/locked.jpg"
+  start_app "" "$r10/locked-dir.png" "$r10/locked-dir.jpg"
+  wait_shrunk 2 60 "$r10"/*
+  check "app still running" "$(alive)" "yes"
+  check "both files optimized in an unwritable directory" "$(shrunk_count "$r10"/*)" "2"
+  stop_app
+  chmod u+w "$r10"
+
+  echo "### R11 a read-only file fails without a fake saving ###"
+  # The one case that genuinely cannot be written. It has to be reported as a
+  # failure in the log and leave the file alone, rather than parsing the
+  # optimizer's optimistic output into a saving that never happened.
+  r11="$WORK/r11"
+  mkdir -p "$r11"
+  cp "$PNG_SOURCE" "$r11/readonly.png"
+  cp "$JPG_SOURCE" "$r11/readonly.jpg"
+  record "$r11"/*
+  chmod a-w "$r11"/readonly.*
+  start_app "" "$r11/readonly.png" "$r11/readonly.jpg"
   # Nothing can be written, so wait out the time an optimization would have taken.
   sleep 8
   check "app still running" "$(alive)" "yes"
-  check "files left untouched" "$(shrunk_count "$r10"/*)" "0"
-  # The point of the case: the log has to say it failed rather than stay silent.
+  check "files left untouched" "$(shrunk_count "$r11"/*)" "0"
   check "failure was logged" \
-    "$(grep -qE "exited with status" "$WORK/app.log" && echo yes || echo no)" "yes"
+    "$(grep -qE "Could not write the result back" "$WORK/app.log" && echo yes || echo no)" "yes"
   stop_app
-  chmod u+w "$r10"
+  chmod u+w "$r11"/readonly.*
 fi
 
 echo

--- a/.github/scripts/regression-test.sh
+++ b/.github/scripts/regression-test.sh
@@ -13,6 +13,7 @@
 #   R7  no diagnostics for input that is perfectly fine.
 #   R8  Ctrl+Q, which the app description promises.
 #   R9  a bmp, which the app used to accept and then not optimize.
+#   R10 a file that cannot be rewritten, which used to report a fake saving.
 #
 # Usage, against an installed tree:
 #
@@ -325,6 +326,36 @@ check "the file is unchanged" "$(cmp -s "$BMP_SOURCE" "$r9/photo.bmp" && echo ye
 # The one that catches the old behaviour: it left a second file behind.
 check "files in the directory" "$(find "$r9" -type f | wc -l | tr -d ' ')" "1"
 stop_app
+
+echo "### R10 a file that cannot be rewritten is reported as unchanged ###"
+# Both optimizers replace a file by writing a temporary one next to it and
+# renaming, so a directory they cannot write to fails the whole operation. What
+# made that dangerous is that jpegoptim still prints "11261 --> 11067 bytes,
+# optimized." on stdout before it tries, and the app used to parse that line
+# without looking at the exit status. The row then claimed a saving on a file
+# that was untouched. This is also what a document portal path behaves like.
+if [ "$(id -u)" = "0" ]; then
+  # root is exempt from directory permissions, so the write succeeds and the case
+  # proves nothing. CI runs the suite as an ordinary user, where it does apply.
+  echo "  SKIP running as root, which ignores directory permissions"
+else
+  r10="$WORK/r10"
+  mkdir -p "$r10"
+  cp "$PNG_SOURCE" "$r10/locked.png"
+  cp "$JPG_SOURCE" "$r10/locked.jpg"
+  record "$r10"/*
+  chmod a-w "$r10"
+  start_app "" "$r10/locked.png" "$r10/locked.jpg"
+  # Nothing can be written, so wait out the time an optimization would have taken.
+  sleep 8
+  check "app still running" "$(alive)" "yes"
+  check "files left untouched" "$(shrunk_count "$r10"/*)" "0"
+  # The point of the case: the log has to say it failed rather than stay silent.
+  check "failure was logged" \
+    "$(grep -qE "exited with status" "$WORK/app.log" && echo yes || echo no)" "yes"
+  stop_app
+  chmod u+w "$r10"
+fi
 
 echo
 if [ "$failed" -ne 0 ]; then

--- a/com.github.gijsgoudzwaard.image-optimizer.yml
+++ b/com.github.gijsgoudzwaard.image-optimizer.yml
@@ -12,14 +12,25 @@ sdk: io.elementary.Sdk
 # as your app ID
 command: com.github.gijsgoudzwaard.image-optimizer
 
-# Here we can specify the kinds of permissions our app needs to run. Since we're
-# not using hardware like webcams, making sound, or reading external files, we
-# only need permission to draw our app on screen using either X11 or Wayland.
+# Every permission here has to earn its place, because each one shows up on the
+# app's Flathub listing. There is deliberately no --filesystem argument: files
+# reach the app through the portals instead. Gtk.FileDialog goes through the file
+# chooser portal, drag and drop through the file transfer portal that GDK speaks
+# on its own, and paths from "Open With" through --file-forwarding below. All
+# three hand over a path in this app's document namespace, which is exactly the
+# one file the user pointed at and nothing around it.
 finish-args:
+  # Shared memory with the X server. Without it X11 falls back to copying every
+  # frame over the socket, which is visibly slow.
   - '--share=ipc'
+  # Only claimed when the session is actually X11, so a Wayland session gets no
+  # X11 access at all.
   - '--socket=fallback-x11'
+  # The primary display path.
   - '--socket=wayland'
-  - '--filesystem=home'
+  # Turns the host paths that a file manager passes on "Open With" into document
+  # portal paths. Without it those arguments name files the sandbox cannot open.
+  - '--file-forwarding'
 
 # This section is where you list all the source code required to build your app.
 # If we had external dependencies that weren't included in our SDK, we would list
@@ -44,3 +55,11 @@ modules:
     sources:
       - type: dir
         path: .
+    # --file-forwarding only does anything when the Exec line marks which of its
+    # arguments are files, and it marks them with @@. That marker cannot live in
+    # the desktop file in the repository: outside a flatpak nothing strips it, so
+    # a source install and the snap would pass a literal "@@" to the app. So it
+    # is added here, to the installed copy only.
+    post-install:
+      - sed -i 's|Exec=com.github.gijsgoudzwaard.image-optimizer %F|Exec=com.github.gijsgoudzwaard.image-optimizer @@ %F @@|'
+        /app/share/applications/com.github.gijsgoudzwaard.image-optimizer.desktop

--- a/com.github.gijsgoudzwaard.image-optimizer.yml
+++ b/com.github.gijsgoudzwaard.image-optimizer.yml
@@ -14,11 +14,15 @@ command: com.github.gijsgoudzwaard.image-optimizer
 
 # Every permission here has to earn its place, because each one shows up on the
 # app's Flathub listing. There is deliberately no --filesystem argument: files
-# reach the app through the portals instead. Gtk.FileDialog goes through the file
-# chooser portal, drag and drop through the file transfer portal that GDK speaks
-# on its own, and paths from "Open With" through --file-forwarding below. All
-# three hand over a path in this app's document namespace, which is exactly the
-# one file the user pointed at and nothing around it.
+# reach the app through the portals instead, and all three routes hand over a
+# path in this app's own document namespace, which is the one file the user
+# pointed at and nothing around it.
+#
+#   file chooser   Gtk.FileDialog, which GTK routes through the portal
+#   drag and drop  GDK speaks org.freedesktop.portal.FileTransfer by itself
+#   Open With      flatpak rewrites the %F in the desktop file into its own file
+#                  forwarding tokens when it exports the launcher, so this needs
+#                  nothing here and nothing in the desktop file
 finish-args:
   # Shared memory with the X server. Without it X11 falls back to copying every
   # frame over the socket, which is visibly slow.
@@ -28,9 +32,6 @@ finish-args:
   - '--socket=fallback-x11'
   # The primary display path.
   - '--socket=wayland'
-  # Turns the host paths that a file manager passes on "Open With" into document
-  # portal paths. Without it those arguments name files the sandbox cannot open.
-  - '--file-forwarding'
 
 # This section is where you list all the source code required to build your app.
 # If we had external dependencies that weren't included in our SDK, we would list
@@ -55,11 +56,3 @@ modules:
     sources:
       - type: dir
         path: .
-    # --file-forwarding only does anything when the Exec line marks which of its
-    # arguments are files, and it marks them with @@. That marker cannot live in
-    # the desktop file in the repository: outside a flatpak nothing strips it, so
-    # a source install and the snap would pass a literal "@@" to the app. So it
-    # is added here, to the installed copy only.
-    post-install:
-      - sed -i 's|Exec=com.github.gijsgoudzwaard.image-optimizer %F|Exec=com.github.gijsgoudzwaard.image-optimizer @@ %F @@|'
-        /app/share/applications/com.github.gijsgoudzwaard.image-optimizer.desktop

--- a/data/com.github.gijsgoudzwaard.image-optimizer.appdata.xml.in
+++ b/data/com.github.gijsgoudzwaard.image-optimizer.appdata.xml.in
@@ -80,6 +80,15 @@
       <value key="x-appcenter-stripe">pk_live_51AhbXkAINoIuuUE3zGg5JG2PvD3IcxMONFdFJZiMawOTGsCzcxxZAREnvLKeoGyMxEVfJpSYfjFzsDZa2bV6eEEb00nj0bUJl8</value>
    </custom>
    <releases>
+      <release version="0.4.0" date="2026-08-12">
+         <description>
+            <ul>
+               <li>Image Optimizer no longer asks for access to your whole home folder. It is handed only the images you pick, through the system file chooser, and dragging images in keeps working the same way</li>
+               <li>Images in a folder you have no permission to write to are now optimized as well, where they used to be skipped</li>
+               <li>Fixed an image that could not be rewritten being reported as optimized, with a saving it never made</li>
+            </ul>
+         </description>
+      </release>
       <release version="0.3.0" date="2026-07-26">
          <description>
             <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('com.github.gijsgoudzwaard.image-optimizer', 'vala', 'c',
-  version: '0.3.0',
+  version: '0.4.0',
   meson_version: '>= 0.59.0')
 
 gnome = import('gnome')

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ executable(
     'src/Widgets/List.vala',
     'src/Widgets/ImageRow.vala',
     'src/Utils/Utils.vala',
+    'src/Utils/Rewrite.vala',
     'src/Utils/Image.vala',
     'src/Utils/Optimizer.vala',
     'src/Utils/JpegOptim.vala',

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -170,6 +170,16 @@ public class MainWindow : Gtk.Window {
    * @return bool
    */
   private bool on_drop (Value value, double x, double y) {
+    // Nothing here asks for the document portal, and that is deliberate: GDK
+    // offers and accepts application/vnd.portal.filetransfer and calls
+    // org.freedesktop.portal.FileTransfer itself, so inside a sandbox the paths
+    // below already point into this app's document namespace and carry a grant.
+    // That is what lets the manifest ship without --filesystem=home.
+    //
+    // It depends on the app being dragged from doing the same. Anything that
+    // offers plain file:// URIs instead hands over a path the sandbox cannot
+    // open, which shows up as a row that fails to optimize rather than as a
+    // crash. Sources that use GTK, which includes Files, do the portal side.
     unowned var list = (Gdk.FileList) value;
 
     list.get_files ().foreach ((file) => {

--- a/src/Utils/JpegOptim.vala
+++ b/src/Utils/JpegOptim.vala
@@ -106,6 +106,8 @@ public class JpegOptim {
 
     argv += image;
 
+    var new_size = 0;
+
     try {
       string standard_output;
       string standard_error;
@@ -122,11 +124,30 @@ public class JpegOptim {
         out status
       );
 
-      // jpegoptim reports on stdout.
-      this.list.update_size (image, this.get_new_size (standard_output));
+      // jpegoptim prints its " --> " line before it tries to put the result in
+      // place, so that line is not proof that anything was written. A directory
+      // it cannot create its temporary file in gets the optimistic line on
+      // stdout and exit code 3, and parsing the line anyway made the list report
+      // a saving on a file that was never touched. The status is the only honest
+      // signal, so read it.
+      if (status == 0) {
+        // jpegoptim reports on stdout.
+        new_size = this.get_new_size (standard_output);
+      } else {
+        warning (
+          "jpegoptim exited with status %d for \"%s\": %s",
+          status,
+          image,
+          standard_error
+        );
+      }
     } catch (Error e) {
       warning ("Failed to run jpegoptim on \"%s\": %s", image, e.message);
     }
+
+    // A zero means "nothing was written", which the list turns back into the
+    // original size, so the row reports no saving instead of a made up one.
+    this.list.update_size (image, new_size);
   }
 
   /**

--- a/src/Utils/JpegOptim.vala
+++ b/src/Utils/JpegOptim.vala
@@ -98,13 +98,23 @@ public class JpegOptim {
    * @return void
    */
   private void compress_one (string image) {
+    // The optimizer runs on a copy inside the sandbox, never on the file the
+    // user picked. See Rewrite for why.
+    var rewrite = new Rewrite (image);
+
+    if (rewrite.working_path == null) {
+      this.list.update_size (image, 0);
+
+      return;
+    }
+
     string[] argv = { "jpegoptim" };
 
     foreach (var arg in this.args) {
       argv += arg;
     }
 
-    argv += image;
+    argv += rewrite.working_path;
 
     var new_size = 0;
 
@@ -131,8 +141,12 @@ public class JpegOptim {
       // a saving on a file that was never touched. The status is the only honest
       // signal, so read it.
       if (status == 0) {
-        // jpegoptim reports on stdout.
-        new_size = this.get_new_size (standard_output);
+        // jpegoptim reports on stdout. The size it prints describes the copy, so
+        // it is only used to tell "it did something" from "already optimal"; the
+        // size that reaches the list is the number of bytes actually written.
+        if (this.get_new_size (standard_output) > 0) {
+          new_size = rewrite.commit ();
+        }
       } else {
         warning (
           "jpegoptim exited with status %d for \"%s\": %s",
@@ -144,6 +158,10 @@ public class JpegOptim {
     } catch (Error e) {
       warning ("Failed to run jpegoptim on \"%s\": %s", image, e.message);
     }
+
+    // Always, so a failure or a quit halfway through does not leave the copy
+    // behind.
+    rewrite.cleanup ();
 
     // A zero means "nothing was written", which the list turns back into the
     // original size, so the row reports no saving instead of a made up one.

--- a/src/Utils/OptiPng.vala
+++ b/src/Utils/OptiPng.vala
@@ -98,6 +98,8 @@ public class OptiPng {
 
     argv += image;
 
+    var new_size = 0;
+
     try {
       string standard_output;
       string standard_error;
@@ -114,17 +116,28 @@ public class OptiPng {
         out status
       );
 
-      var new_size = 0;
-
-      // optipng reports on stderr, stdout stays empty.
-      if (! standard_error.contains ("is already optimized")) {
+      // Same reasoning as in JpegOptim: only the exit status says whether the
+      // result reached the disk. optipng fails with "Can't back up the input
+      // file" when it cannot write next to the original, and without this check
+      // that turned into a reported saving on an untouched file.
+      if (status != 0) {
+        warning (
+          "optipng exited with status %d for \"%s\": %s",
+          status,
+          image,
+          standard_error
+        );
+      } else if (! standard_error.contains ("is already optimized")) {
+        // optipng reports on stderr, stdout stays empty.
         new_size = this.get_new_size (standard_error);
       }
-
-      this.list.update_size (image, new_size);
     } catch (Error e) {
       warning ("Failed to run optipng on \"%s\": %s", image, e.message);
     }
+
+    // A zero means "nothing was written", which the list turns back into the
+    // original size, so the row reports no saving instead of a made up one.
+    this.list.update_size (image, new_size);
   }
 
   /**

--- a/src/Utils/OptiPng.vala
+++ b/src/Utils/OptiPng.vala
@@ -90,13 +90,23 @@ public class OptiPng {
    * @return void
    */
   private void compress_one (string image) {
+    // The optimizer runs on a copy inside the sandbox, never on the file the
+    // user picked. See Rewrite for why.
+    var rewrite = new Rewrite (image);
+
+    if (rewrite.working_path == null) {
+      this.list.update_size (image, 0);
+
+      return;
+    }
+
     string[] argv = { "optipng" };
 
     foreach (var arg in this.args) {
       argv += arg;
     }
 
-    argv += image;
+    argv += rewrite.working_path;
 
     var new_size = 0;
 
@@ -128,12 +138,20 @@ public class OptiPng {
           standard_error
         );
       } else if (! standard_error.contains ("is already optimized")) {
-        // optipng reports on stderr, stdout stays empty.
-        new_size = this.get_new_size (standard_error);
+        // optipng reports on stderr, stdout stays empty. Its number describes
+        // the copy, so it only decides whether there is anything to write back;
+        // the size handed to the list is what was actually written.
+        if (this.get_new_size (standard_error) > 0) {
+          new_size = rewrite.commit ();
+        }
       }
     } catch (Error e) {
       warning ("Failed to run optipng on \"%s\": %s", image, e.message);
     }
+
+    // Always, so a failure or a quit halfway through does not leave the copy
+    // behind.
+    rewrite.cleanup ();
 
     // A zero means "nothing was written", which the list turns back into the
     // original size, so the row reports no saving instead of a made up one.

--- a/src/Utils/Rewrite.vala
+++ b/src/Utils/Rewrite.vala
@@ -1,0 +1,196 @@
+/**
+ * Rewrites one image in place without ever renaming another file over it.
+ *
+ * Both jpegoptim and optipng replace a file by writing a temporary one next to
+ * it and renaming. Under the XDG document portal the app is handed a path inside
+ * a per-document FUSE directory, and the grant is bound to that one file: a
+ * rename across it fails, and with it the whole optimization. Measured outside
+ * the sandbox, the same thing happens whenever the directory is not writable,
+ * which is why this class exists rather than a portal specific workaround.
+ *
+ * So the file the optimizers see is a copy inside the sandbox, and the bytes
+ * they produce are written back over the original file descriptor. The original
+ * inode is never replaced, so whatever the portal granted stays valid.
+ *
+ * The copy also means the optimizers' own --preserve no longer decides what the
+ * modification time ends up being, because it is the copy they preserve. This
+ * class reads the original time before touching anything and puts it back after,
+ * which is how PNG and JPEG both keep their timestamp now.
+ */
+public class Rewrite {
+
+  /**
+   * Path of the image the caller wants rewritten.
+   *
+   * @var string
+   */
+  public string original_path { get; private set; }
+
+  /**
+   * Path of the copy the optimizer should be pointed at, or null when the copy
+   * could not be made.
+   *
+   * @var string?
+   */
+  public string? working_path { get; private set; default = null; }
+
+  /**
+   * Modification time of the original, so it can be restored afterwards.
+   *
+   * @var DateTime?
+   */
+  private DateTime? modified = null;
+
+  /**
+   * Take a copy of the image inside the sandbox. Check working_path afterwards:
+   * it stays null when there was nothing to copy or nowhere to copy it to, and
+   * the caller should then report a failure rather than run the optimizer.
+   *
+   * @param string path
+   */
+  public Rewrite (string path) {
+    this.original_path = path;
+
+    var original = File.new_for_path (path);
+
+    try {
+      // The time has to be read before the copy, because writing the result
+      // back later stamps the original with the current time.
+      var info = original.query_info (
+        FileAttribute.TIME_MODIFIED + "," + FileAttribute.TIME_MODIFIED_USEC,
+        FileQueryInfoFlags.NONE
+      );
+      this.modified = info.get_modification_date_time ();
+    } catch (Error e) {
+      warning ("Could not read the modification time of \"%s\": %s", path, e.message);
+    }
+
+    try {
+      // The runtime directory is preferred over /tmp: inside a flatpak it is
+      // private to this app and the system clears it, so a copy left behind by
+      // a hard kill does not outlive the session.
+      var parent = Environment.get_user_runtime_dir () ?? Environment.get_tmp_dir ();
+      var directory = Path.build_filename (parent, "image-optimizer");
+
+      if (DirUtils.create_with_parents (directory, 0700) != 0) {
+        warning ("Could not create \"%s\"", directory);
+        return;
+      }
+
+      // The extension is kept because both optimizers decide what to do by
+      // looking at the contents, but a recognisable name helps when a copy does
+      // survive a crash.
+      var name = Path.get_basename (path);
+      var candidate = Path.build_filename (directory, "%d-%s".printf (Random.int_range (0, int.MAX), name));
+
+      original.copy (
+        File.new_for_path (candidate),
+        FileCopyFlags.OVERWRITE | FileCopyFlags.ALL_METADATA,
+        null,
+        null
+      );
+
+      this.working_path = candidate;
+    } catch (Error e) {
+      warning ("Could not copy \"%s\" for optimizing: %s", path, e.message);
+    }
+  }
+
+  /**
+   * Write the optimized bytes back over the original and restore its
+   * modification time. Returns the new size, or 0 when nothing was written.
+   *
+   * @return int
+   */
+  public int commit () {
+    if (this.working_path == null) {
+      return 0;
+    }
+
+    uint8[] contents;
+
+    try {
+      FileUtils.get_data (this.working_path, out contents);
+    } catch (Error e) {
+      warning ("Could not read the optimized copy of \"%s\": %s", this.original_path, e.message);
+      return 0;
+    }
+
+    if (contents.length == 0) {
+      warning ("The optimized copy of \"%s\" was empty, leaving the original alone", this.original_path);
+      return 0;
+    }
+
+    try {
+      // open_readwrite, not replace: File.replace writes a new file and renames
+      // it over this one, which is exactly what has to be avoided here.
+      var stream = File.new_for_path (this.original_path).open_readwrite ();
+
+      stream.seek (0, SeekType.SET);
+
+      size_t written;
+      stream.output_stream.write_all (contents, out written);
+      stream.output_stream.flush ();
+
+      // The result is smaller than what was there, so the tail of the old file
+      // has to go. Without this the file keeps its original length and the
+      // leftover bytes corrupt it.
+      if (stream.can_truncate ()) {
+        stream.truncate (contents.length);
+      } else {
+        warning ("Cannot truncate \"%s\", leaving it alone", this.original_path);
+        stream.close ();
+
+        return 0;
+      }
+
+      stream.close ();
+    } catch (Error e) {
+      warning ("Could not write the result back to \"%s\": %s", this.original_path, e.message);
+      return 0;
+    }
+
+    this.restore_modification_time ();
+
+    return contents.length;
+  }
+
+  /**
+   * Remove the copy. Safe to call more than once, and safe to call when there
+   * never was a copy.
+   *
+   * @return void
+   */
+  public void cleanup () {
+    if (this.working_path == null) {
+      return;
+    }
+
+    if (FileUtils.unlink (this.working_path) != 0 && FileUtils.test (this.working_path, FileTest.EXISTS)) {
+      warning ("Could not remove the temporary copy \"%s\"", this.working_path);
+    }
+
+    this.working_path = null;
+  }
+
+  /**
+   * Put the original modification time back, so optimizing a folder does not
+   * reorder a photo library sorted by date.
+   *
+   * @return void
+   */
+  private void restore_modification_time () {
+    if (this.modified == null) {
+      return;
+    }
+
+    try {
+      var info = new FileInfo ();
+      info.set_modification_date_time (this.modified);
+
+      File.new_for_path (this.original_path).set_attributes_from_info (info, FileQueryInfoFlags.NONE);
+    } catch (Error e) {
+      warning ("Could not restore the modification time of \"%s\": %s", this.original_path, e.message);
+    }
+  }
+}

--- a/src/Utils/Rewrite.vala
+++ b/src/Utils/Rewrite.vala
@@ -9,8 +9,20 @@
  * which is why this class exists rather than a portal specific workaround.
  *
  * So the file the optimizers see is a copy inside the sandbox, and the bytes
- * they produce are written back over the original file descriptor. The original
- * inode is never replaced, so whatever the portal granted stays valid.
+ * they produce are written back over the original file descriptor. Nothing here
+ * renames anything, which is what the portal path needs.
+ *
+ * That is not the same as promising the inode survives. Measured on a real
+ * sandboxed run, a file picked through the portal came back with a new inode
+ * (3932178 became 3933511) while its modification time and contents were exactly
+ * as intended. The document portal is a FUSE layer that commits a write by
+ * putting the bytes in a temporary file and renaming that over the real one, so
+ * the inode changes a level below this code. A file the app can reach without
+ * the portal keeps its inode.
+ *
+ * The practical consequence is that optimizing a file with more than one hard
+ * link splits it, and the other links keep the old contents. That was already
+ * true before this class existed, because the optimizers renamed as well.
  *
  * The copy also means the optimizers' own --preserve no longer decides what the
  * modification time ends up being, because it is the copy they preserve. This


### PR DESCRIPTION
<ul>
               <li>Image Optimizer no longer asks for access to your whole home folder. It is handed only the images you pick, through the system file chooser, and dragging images in keeps working the same way</li>
               <li>Images in a folder you have no permission to write to are now optimized as well, where they used to be skipped</li>
               <li>Fixed an image that could not be rewritten being reported as optimized, with a saving it never made</li>
            </ul>